### PR TITLE
feat: created export isPedOnCarry()

### DIFF
--- a/client/main.lua
+++ b/client/main.lua
@@ -11,6 +11,12 @@ lib.locale()
 --- Functions
 --
 
+local function isPedOnCarry()
+
+    return beingCarried
+end
+exports('isPedOnCarry', isPedOnCarry)
+
 local function disableCamera(vehicle)
     disableCameraTemp = true
 


### PR DESCRIPTION
Usage: exports['s1n_carryandhideintrunk']:isPedOnCarry() Returns true/false

Added export which can be used in other scripts to disable player from doing action while he is on carry (for example hands up)